### PR TITLE
Add fix for Symfony >4.2 in Configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,8 +19,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $builder->root('gpslab_pagination')
+        if (method_exists('Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode')) { // Symfony >4.2
+            $builder = new TreeBuilder('gpslab_pagination');
+            $root = $builder->getRootNode();
+        } else {
+            $builder = new TreeBuilder();
+            $root = $builder->root('gpslab_pagination');
+        }
+
+        $root
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('max_navigate')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,12 +19,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        if (method_exists('Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode')) { // Symfony >4.2
-            $builder = new TreeBuilder('gpslab_pagination');
-            $root = $builder->getRootNode();
+        $tree_builder = new TreeBuilder('gpslab_pagination');
+
+        if (method_exists($tree_builder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $root = $tree_builder->getRootNode();
         } else {
-            $builder = new TreeBuilder();
-            $root = $builder->root('gpslab_pagination');
+            // Symfony 4.1 and below
+            $root = $tree_builder->root('gpslab_pagination');
         }
 
         $root
@@ -41,6 +43,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end();
 
-        return $builder;
+        return $tree_builder;
     }
 }


### PR DESCRIPTION
> The "GpsLab\Bundle\PaginationBundle\DependencyInjection\Configuration::root()" method called for the "gpslab_pagination" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.

> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
