### PR TITLE
Rename undefined type callback to callable

### DIFF
--- a/src/Service/Configuration.php
+++ b/src/Service/Configuration.php
@@ -46,7 +46,7 @@ class Configuration
     private $max_navigate = self::DEFAULT_LIST_LENGTH;
 
     /**
-     * @var string|callback
+     * @var string|callable
      */
     private $page_link = self::DEFAULT_PAGE_LINK;
 
@@ -137,7 +137,7 @@ class Configuration
     }
 
     /**
-     * @return string|callback
+     * @return string|callable
      */
     public function getPageLink()
     {
@@ -156,7 +156,7 @@ class Configuration
      * }
      * </code>
      *
-     * @param string|callback $page_link
+     * @param string|callable $page_link
      *
      * @return self
      */

--- a/tests/Service/ViewTest.php
+++ b/tests/Service/ViewTest.php
@@ -118,7 +118,7 @@ class ViewTest extends TestCase
     }
 
     /**
-     * @param string|callback $page_link
+     * @param string|callable $page_link
      * @param int             $number
      *
      * @return string
@@ -131,7 +131,7 @@ class ViewTest extends TestCase
     /**
      * @dataProvider getFirstPageLinks
      *
-     * @param string|callback $page_link
+     * @param string|callable $page_link
      * @param string          $first_page_link
      */
     public function testGetFirst($page_link, $first_page_link)
@@ -162,7 +162,7 @@ class ViewTest extends TestCase
     /**
      * @dataProvider getPageLinks
      *
-     * @param string|callback $page_link
+     * @param string|callable $page_link
      */
     public function testGetPrev($page_link)
     {
@@ -188,7 +188,7 @@ class ViewTest extends TestCase
     /**
      * @dataProvider getFirstPageLinks
      *
-     * @param string|callback $page_link
+     * @param string|callable $page_link
      * @param string          $first_page_link
      */
     public function testGetCurrent($page_link, $first_page_link)
@@ -219,7 +219,7 @@ class ViewTest extends TestCase
     /**
      * @dataProvider getPageLinks
      *
-     * @param string|callback $page_link
+     * @param string|callable $page_link
      */
     public function testGetNext($page_link)
     {
@@ -249,7 +249,7 @@ class ViewTest extends TestCase
     /**
      * @dataProvider getPageLinks
      *
-     * @param string|callback $page_link
+     * @param string|callable $page_link
      */
     public function testGetLast($page_link)
     {


### PR DESCRIPTION
Fix typo. Rename undefined type `callback` to `callable`.