### PR TITLE
Use static assert*() methods as a static in tests

### DIFF
--- a/tests/DependencyInjection/GpsLabPaginationExtensionTest.php
+++ b/tests/DependencyInjection/GpsLabPaginationExtensionTest.php
@@ -30,9 +30,9 @@ class GpsLabPaginationExtensionTest extends TestCase
         $container = new ContainerBuilder();
         $this->extension->load([], $container);
 
-        $this->assertEquals(5, $container->getParameter('pagination.max_navigate'));
-        $this->assertEquals('page', $container->getParameter('pagination.parameter_name'));
-        $this->assertEquals(
+        self::assertEquals(5, $container->getParameter('pagination.max_navigate'));
+        self::assertEquals('page', $container->getParameter('pagination.parameter_name'));
+        self::assertEquals(
             'GpsLabPaginationBundle::pagination.html.twig',
             $container->getParameter('pagination.template')
         );
@@ -40,6 +40,6 @@ class GpsLabPaginationExtensionTest extends TestCase
 
     public function testGetAlias()
     {
-        $this->assertEquals('gpslab_pagination', $this->extension->getAlias());
+        self::assertEquals('gpslab_pagination', $this->extension->getAlias());
     }
 }

--- a/tests/Entity/NodeTest.php
+++ b/tests/Entity/NodeTest.php
@@ -35,8 +35,8 @@ class NodeTest extends TestCase
     public function test($page, $link, $is_current)
     {
         $node = new Node($page, $link, $is_current);
-        $this->assertEquals($page, $node->getPage());
-        $this->assertEquals($link, $node->getLink());
-        $this->assertEquals($is_current, $node->isCurrent());
+        self::assertEquals($page, $node->getPage());
+        self::assertEquals($link, $node->getLink());
+        self::assertEquals($is_current, $node->isCurrent());
     }
 }

--- a/tests/Exception/IncorrectPageNumberExceptionTest.php
+++ b/tests/Exception/IncorrectPageNumberExceptionTest.php
@@ -21,8 +21,8 @@ class IncorrectPageNumberExceptionTest extends TestCase
 
         $exception = IncorrectPageNumberException::incorrect($current_page);
 
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Exception\IncorrectPageNumberException', $exception);
-        $this->assertInstanceOf('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', $exception);
-        $this->assertEquals($message, $exception->getMessage());
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Exception\IncorrectPageNumberException', $exception);
+        self::assertInstanceOf('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', $exception);
+        self::assertEquals($message, $exception->getMessage());
     }
 }

--- a/tests/Exception/OutOfRangeExceptionTest.php
+++ b/tests/Exception/OutOfRangeExceptionTest.php
@@ -22,8 +22,8 @@ class OutOfRangeExceptionTest extends TestCase
 
         $exception = OutOfRangeException::out($current_page, $total_pages);
 
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Exception\OutOfRangeException', $exception);
-        $this->assertInstanceOf('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', $exception);
-        $this->assertEquals($message, $exception->getMessage());
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Exception\OutOfRangeException', $exception);
+        self::assertInstanceOf('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', $exception);
+        self::assertEquals($message, $exception->getMessage());
     }
 }

--- a/tests/GpsLabPaginationBundleTest.php
+++ b/tests/GpsLabPaginationBundleTest.php
@@ -18,7 +18,7 @@ class GpsLabPaginationBundleTest extends TestCase
         $bundle = new GpsLabPaginationBundle();
         $extension = $bundle->getContainerExtension();
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'GpsLab\Bundle\PaginationBundle\DependencyInjection\GpsLabPaginationExtension',
             $extension
         );

--- a/tests/Service/BuilderTest.php
+++ b/tests/Service/BuilderTest.php
@@ -62,7 +62,7 @@ class BuilderTest extends TestCase
     {
         $builder = new Builder($this->router, 5, 'p');
 
-        $this->assertEquals('?p=%d', $builder->paginate(10, 3)->getPageLink());
+        self::assertEquals('?p=%d', $builder->paginate(10, 3)->getPageLink());
     }
 
     /**
@@ -88,9 +88,9 @@ class BuilderTest extends TestCase
         $builder = new Builder($this->router, $max_navigate, 'page');
         $config = $builder->paginate($total_pages, $current_page);
 
-        $this->assertEquals($max_navigate, $config->getMaxNavigate());
-        $this->assertEquals($total_pages, $config->getTotalPages());
-        $this->assertEquals($current_page, $config->getCurrentPage());
+        self::assertEquals($max_navigate, $config->getMaxNavigate());
+        self::assertEquals($total_pages, $config->getTotalPages());
+        self::assertEquals($current_page, $config->getCurrentPage());
     }
 
     /**
@@ -132,9 +132,9 @@ class BuilderTest extends TestCase
         $builder = new Builder($this->router, $max_navigate, 'page');
         $config = $builder->paginateQuery($this->query_builder, $per_page, $current_page);
 
-        $this->assertEquals($max_navigate, $config->getMaxNavigate());
-        $this->assertEquals(ceil($total / $per_page), $config->getTotalPages());
-        $this->assertEquals($current_page, $config->getCurrentPage());
+        self::assertEquals($max_navigate, $config->getMaxNavigate());
+        self::assertEquals(ceil($total / $per_page), $config->getTotalPages());
+        self::assertEquals($current_page, $config->getCurrentPage());
     }
 
     /**
@@ -228,14 +228,14 @@ class BuilderTest extends TestCase
         $builder = new Builder($this->router, $max_navigate, 'page');
         $config = $builder->paginateRequest($this->request, $total_pages, $parameter_name, $reference_type);
 
-        $this->assertEquals($max_navigate, $config->getMaxNavigate());
-        $this->assertEquals($total_pages, $config->getTotalPages());
-        $this->assertEquals(1, $config->getCurrentPage());
+        self::assertEquals($max_navigate, $config->getMaxNavigate());
+        self::assertEquals($total_pages, $config->getTotalPages());
+        self::assertEquals(1, $config->getCurrentPage());
         unset($all_params['p']);
-        $this->assertEquals($route.http_build_query($all_params), $config->getFirstPageLink());
-        $this->assertInstanceOf('Closure', $config->getPageLink());
+        self::assertEquals($route.http_build_query($all_params), $config->getFirstPageLink());
+        self::assertInstanceOf('Closure', $config->getPageLink());
         $page_number = 3;
-        $this->assertEquals(
+        self::assertEquals(
             $route.http_build_query($all_params + [$parameter_name => $page_number]),
             call_user_func($config->getPageLink(), $page_number)
         );
@@ -342,14 +342,14 @@ class BuilderTest extends TestCase
             $reference_type
         );
 
-        $this->assertEquals($max_navigate, $config->getMaxNavigate());
-        $this->assertEquals(ceil($total / $per_page), $config->getTotalPages());
-        $this->assertEquals($current_page, $config->getCurrentPage());
+        self::assertEquals($max_navigate, $config->getMaxNavigate());
+        self::assertEquals(ceil($total / $per_page), $config->getTotalPages());
+        self::assertEquals($current_page, $config->getCurrentPage());
         unset($all_params['p']);
-        $this->assertEquals($route.http_build_query($all_params), $config->getFirstPageLink());
-        $this->assertInstanceOf('Closure', $config->getPageLink());
+        self::assertEquals($route.http_build_query($all_params), $config->getFirstPageLink());
+        self::assertInstanceOf('Closure', $config->getPageLink());
         $page_number = 3;
-        $this->assertEquals(
+        self::assertEquals(
             $route.http_build_query($all_params + [$parameter_name => $page_number]),
             call_user_func($config->getPageLink(), $page_number)
         );

--- a/tests/Service/ConfigurationTest.php
+++ b/tests/Service/ConfigurationTest.php
@@ -26,7 +26,7 @@ class ConfigurationTest extends TestCase
 
     public function testDefaultPageLink()
     {
-        $this->assertEquals('?page=%d', $this->config->getPageLink());
+        self::assertEquals('?page=%d', $this->config->getPageLink());
     }
 
     /**
@@ -49,8 +49,8 @@ class ConfigurationTest extends TestCase
     public function testConstruct($total_pages, $current_page)
     {
         $config = new Configuration($total_pages, $current_page);
-        $this->assertEquals($total_pages, $config->getTotalPages());
-        $this->assertEquals($current_page, $config->getCurrentPage());
+        self::assertEquals($total_pages, $config->getTotalPages());
+        self::assertEquals($current_page, $config->getCurrentPage());
     }
 
     /**
@@ -62,8 +62,8 @@ class ConfigurationTest extends TestCase
     public function testCreate($total_pages, $current_page)
     {
         $config = Configuration::create($total_pages, $current_page);
-        $this->assertEquals($total_pages, $config->getTotalPages());
-        $this->assertEquals($current_page, $config->getCurrentPage());
+        self::assertEquals($total_pages, $config->getTotalPages());
+        self::assertEquals($current_page, $config->getCurrentPage());
     }
 
     /**
@@ -123,18 +123,18 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGet($default, $new, $getter, $setter)
     {
-        $this->assertEquals($default, call_user_func([$this->config, $getter]));
-        $this->assertEquals($this->config, call_user_func([$this->config, $setter], $new));
-        $this->assertEquals($new, call_user_func([$this->config, $getter]));
+        self::assertEquals($default, call_user_func([$this->config, $getter]));
+        self::assertEquals($this->config, call_user_func([$this->config, $setter], $new));
+        self::assertEquals($new, call_user_func([$this->config, $getter]));
     }
 
     public function testGetView()
     {
         $view = $this->config->getView();
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Service\View', $view);
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Service\View', $view);
 
         // test lazy load
         $this->config->setPageLink('?p=%s');
-        $this->assertEquals($view, $this->config->getView());
+        self::assertEquals($view, $this->config->getView());
     }
 }

--- a/tests/Service/NavigateRangeTest.php
+++ b/tests/Service/NavigateRangeTest.php
@@ -75,7 +75,7 @@ class NavigateRangeTest extends TestCase
             ->method('getTotalPages')
             ->will($this->returnValue($total_pages));
 
-        $this->assertEquals($left_offset, $this->range->getLeftOffset());
-        $this->assertEquals($right_offset, $this->range->getRightOffset());
+        self::assertEquals($left_offset, $this->range->getLeftOffset());
+        self::assertEquals($right_offset, $this->range->getRightOffset());
     }
 }

--- a/tests/Service/ViewTest.php
+++ b/tests/Service/ViewTest.php
@@ -49,7 +49,7 @@ class ViewTest extends TestCase
             ->will($this->returnValue('110'))
         ;
 
-        $this->assertEquals(110, $this->view->getTotal());
+        self::assertEquals(110, $this->view->getTotal());
     }
 
     /**
@@ -84,7 +84,7 @@ class ViewTest extends TestCase
             ->will($this->returnValue($current_page))
         ;
 
-        $this->assertNull(call_user_func([$this->view, $method]));
+        self::assertNull(call_user_func([$this->view, $method]));
     }
 
     /**
@@ -150,12 +150,12 @@ class ViewTest extends TestCase
             ->will($this->returnValue($page_link));
 
         $node = $this->view->getFirst();
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
-        $this->assertEquals(1, $node->getPage());
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
+        self::assertEquals(1, $node->getPage());
         if ($first_page_link) {
-            $this->assertEquals($first_page_link, $node->getLink());
+            self::assertEquals($first_page_link, $node->getLink());
         } else {
-            $this->assertEquals($this->getLink($page_link, 1), $node->getLink());
+            self::assertEquals($this->getLink($page_link, 1), $node->getLink());
         }
     }
 
@@ -180,9 +180,9 @@ class ViewTest extends TestCase
             ->will($this->returnValue($page_link));
 
         $node = $this->view->getPrev();
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
-        $this->assertEquals(4, $node->getPage());
-        $this->assertEquals($this->getLink($page_link, 4), $node->getLink());
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
+        self::assertEquals(4, $node->getPage());
+        self::assertEquals($this->getLink($page_link, 4), $node->getLink());
     }
 
     /**
@@ -207,12 +207,12 @@ class ViewTest extends TestCase
             ->will($this->returnValue($page_link));
 
         $node = $this->view->getCurrent();
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
-        $this->assertEquals(1, $node->getPage());
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
+        self::assertEquals(1, $node->getPage());
         if ($first_page_link) {
-            $this->assertEquals($first_page_link, $node->getLink());
+            self::assertEquals($first_page_link, $node->getLink());
         } else {
-            $this->assertEquals($this->getLink($page_link, 1), $node->getLink());
+            self::assertEquals($this->getLink($page_link, 1), $node->getLink());
         }
     }
 
@@ -241,9 +241,9 @@ class ViewTest extends TestCase
             ->will($this->returnValue($page_link));
 
         $node = $this->view->getNext();
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
-        $this->assertEquals(6, $node->getPage());
-        $this->assertEquals($this->getLink($page_link, 6), $node->getLink());
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
+        self::assertEquals(6, $node->getPage());
+        self::assertEquals($this->getLink($page_link, 6), $node->getLink());
     }
 
     /**
@@ -271,9 +271,9 @@ class ViewTest extends TestCase
             ->will($this->returnValue($page_link));
 
         $node = $this->view->getLast();
-        $this->assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
-        $this->assertEquals(10, $node->getPage());
-        $this->assertEquals($this->getLink($page_link, 10), $node->getLink());
+        self::assertInstanceOf('GpsLab\Bundle\PaginationBundle\Entity\Node', $node);
+        self::assertEquals(10, $node->getPage());
+        self::assertEquals($this->getLink($page_link, 10), $node->getLink());
     }
 
     /**
@@ -406,7 +406,7 @@ class ViewTest extends TestCase
             ->method('getRightOffset')
             ->will($this->returnValue($right_offset));
 
-        $this->assertEquals($list, $this->view->getIterator());
+        self::assertEquals($list, $this->view->getIterator());
     }
 
     public function testGetIteratorEmpty()
@@ -432,6 +432,6 @@ class ViewTest extends TestCase
             ->expects($this->never())
             ->method('getRightOffset');
 
-        $this->assertEquals(new ArrayCollection(), $this->view->getIterator());
+        self::assertEquals(new ArrayCollection(), $this->view->getIterator());
     }
 }

--- a/tests/Twig/Extension/PaginationExtensionTest.php
+++ b/tests/Twig/Extension/PaginationExtensionTest.php
@@ -34,9 +34,9 @@ class PaginationExtensionTest extends TestCase
     {
         $functions = $this->extension->getFunctions();
 
-        $this->assertInternalType('array', $functions);
-        $this->assertCount(1, $functions);
-        $this->assertInstanceOf('Twig_SimpleFunction', $functions[0]);
+        self::assertInternalType('array', $functions);
+        self::assertCount(1, $functions);
+        self::assertInstanceOf('Twig_SimpleFunction', $functions[0]);
     }
 
     public function testRender()
@@ -58,7 +58,7 @@ class PaginationExtensionTest extends TestCase
             ->method('getView')
             ->will($this->returnValue($view));
 
-        $this->assertEquals($expected, $this->extension->renderPagination(
+        self::assertEquals($expected, $this->extension->renderPagination(
             $env,
             $configuration
         ));
@@ -84,7 +84,7 @@ class PaginationExtensionTest extends TestCase
             ->method('getView')
             ->will($this->returnValue($view));
 
-        $this->assertEquals($expected, $this->extension->renderPagination(
+        self::assertEquals($expected, $this->extension->renderPagination(
             $env,
             $configuration,
             $template,
@@ -111,7 +111,7 @@ class PaginationExtensionTest extends TestCase
             ->method('getView')
             ->will($this->returnValue($view));
 
-        $this->assertEquals($expected, $this->extension->renderPagination(
+        self::assertEquals($expected, $this->extension->renderPagination(
             $env,
             $configuration,
             null,
@@ -121,6 +121,6 @@ class PaginationExtensionTest extends TestCase
 
     public function testGetName()
     {
-        $this->assertEquals('gpslab_pagination_extension', $this->extension->getName());
+        self::assertEquals('gpslab_pagination_extension', $this->extension->getName());
     }
 }

--- a/tests/Twig/Extension/PaginationExtensionTest.php
+++ b/tests/Twig/Extension/PaginationExtensionTest.php
@@ -35,7 +35,7 @@ class PaginationExtensionTest extends TestCase
         $functions = $this->extension->getFunctions();
 
         $this->assertInternalType('array', $functions);
-        $this->assertEquals(1, count($functions));
+        $this->assertCount(1, $functions);
         $this->assertInstanceOf('Twig_SimpleFunction', $functions[0]);
     }
 


### PR DESCRIPTION
Use static `assert*()` methods as a static in tests.