### PR TITLE
GpsLabPaginationBundle::$extension can be false. Correct init GpsLabPaginationExtension.

### DIFF
--- a/src/GpsLabPaginationBundle.php
+++ b/src/GpsLabPaginationBundle.php
@@ -20,7 +20,7 @@ class GpsLabPaginationBundle extends Bundle
      */
     public function getContainerExtension()
     {
-        if ($this->extension === null) {
+        if (!($this->extension instanceof GpsLabPaginationExtension)) {
             $this->extension = new GpsLabPaginationExtension();
         }
 


### PR DESCRIPTION
The expression `$this->extension;` of type `Symfony\Component\DependencyInjection\Extension\ExtensionInterface|false` adds `false` to the return on line 32 which is incompatible with the return type declared by the interface `Symfony\Component\HttpKernel\Bundle\BundleInterface::getContainerExtension` of type `Symfony\Component\DependencyInjection\Extension\ExtensionInterface|null`. It seems like you forgot to handle an error condition.
Filename: `src/GpsLabPaginationBundle.php`
LineNumber: `27`
Link: https://scrutinizer-ci.com/g/gpslab/pagination-bundle/issues/master/files/src/GpsLabPaginationBundle.php?orderField=path&order=asc&honorSelectedPaths=0&issueId=17612480