### PR TITLE
Add hook for support Twig > 2.7

### DIFF
--- a/src/Twig/Extension/PaginationExtension.php
+++ b/src/Twig/Extension/PaginationExtension.php
@@ -8,64 +8,85 @@
  * @license   http://opensource.org/licenses/MIT
  */
 
-namespace GpsLab\Bundle\PaginationBundle\Twig\Extension;
+// hook for support Twig > 2.7
 
-use GpsLab\Bundle\PaginationBundle\Service\Configuration;
-
-class PaginationExtension extends \Twig_Extension
+namespace
 {
-    /**
-     * @var string
-     */
-    private $template = '';
+    use Twig\Extension\AbstractExtension;
+    use Twig\TwigFunction;
 
-    /**
-     * @param string $template
-     */
-    public function __construct($template)
-    {
-        $this->template = $template;
+    if (!class_exists('Twig_Extension') && class_exists('Twig\Extension\AbstractExtension')) {
+        class Twig_Extension extends AbstractExtension
+        {
+        }
     }
 
-    /**
-     * @return array
-     */
-    public function getFunctions()
-    {
-        return [
-            new \Twig_SimpleFunction(
-                'pagination_render',
-                [$this, 'renderPagination'],
-                ['is_safe' => ['html'], 'needs_environment' => true]
-            ),
-        ];
+    if (!class_exists('Twig_SimpleFunction') && class_exists('Twig\TwigFunction')) {
+        class Twig_SimpleFunction extends TwigFunction
+        {
+        }
     }
+}
 
-    /**
-     * @param \Twig_Environment $env
-     * @param Configuration     $pagination
-     * @param string            $template
-     * @param array             $view_params
-     *
-     * @return string
-     */
-    public function renderPagination(
-        \Twig_Environment $env,
-        Configuration $pagination,
-        $template = null,
-        array $view_params = []
-    ) {
-        return $env->render(
-            $template ?: $this->template,
-            array_merge($view_params, ['pagination' => $pagination->getView()])
-        );
-    }
+namespace GpsLab\Bundle\PaginationBundle\Twig\Extension
+{
+    use GpsLab\Bundle\PaginationBundle\Service\Configuration;
 
-    /**
-     * @return string
-     */
-    public function getName()
+    class PaginationExtension extends \Twig_Extension
     {
-        return 'gpslab_pagination_extension';
+        /**
+         * @var string
+         */
+        private $template;
+
+        /**
+         * @param string $template
+         */
+        public function __construct($template)
+        {
+            $this->template = $template;
+        }
+
+        /**
+         * @return array
+         */
+        public function getFunctions()
+        {
+            return [
+                new \Twig_SimpleFunction(
+                    'pagination_render',
+                    [$this, 'renderPagination'],
+                    ['is_safe' => ['html'], 'needs_environment' => true]
+                ),
+            ];
+        }
+
+        /**
+         * @param \Twig_Environment $env
+         * @param Configuration     $pagination
+         * @param string            $template
+         * @param array             $view_params
+         *
+         * @return string
+         */
+        public function renderPagination(
+            \Twig_Environment $env,
+            Configuration $pagination,
+            $template = null,
+            array $view_params = []
+        ) {
+            return $env->render(
+                $template ?: $this->template,
+                array_merge($view_params, ['pagination' => $pagination->getView()])
+            );
+        }
+
+        /**
+         * @return string
+         */
+        public function getName()
+        {
+            return 'gpslab_pagination_extension';
+        }
     }
 }


### PR DESCRIPTION
The class `Twig_Extension` has been deprecated with message: since Twig 2.7, use `Twig\Extension\AbstractExtension` instead
Filename: `src/Twig/Extension/PaginationExtension.php`
LineNumber: `15`
Link: https://scrutinizer-ci.com/g/gpslab/pagination-bundle/issues/master/files/src/Twig/Extension/PaginationExtension.php?orderField=path&order=asc&honorSelectedPaths=0&issueId=39952960

The class `Twig_SimpleFunction` has been deprecated with message: since Twig 2.7, use `Twig\TwigFunction` instead
Filename: `src/Twig/Extension/PaginationExtension.php`
LineNumber: `36`
Link: https://scrutinizer-ci.com/g/gpslab/pagination-bundle/issues/master/files/src/Twig/Extension/PaginationExtension.php?orderField=path&order=asc&honorSelectedPaths=0&issueId=39952959