### PR TITLE
The satooshi/php-coveralls package is abandoned and no longer maintained

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "phpunit/phpunit": "~4.8",
     "scrutinizer/ocular": "~1.3",
-    "satooshi/php-coveralls": "^1.0",
+    "php-coveralls/php-coveralls": "^1.0",
     "friendsofphp/php-cs-fixer": "~2.2",
     "roave/security-advisories": "dev-master"
   }


### PR DESCRIPTION
This [satooshi/php-coveralls](https://packagist.org/packages/satooshi/php-coveralls) package is abandoned and no longer maintained. The author suggests using the [php-coveralls/php-coveralls](https://packagist.org/packages/php-coveralls/php-coveralls) package instead.