### PR TITLE
Use phpunit/phpunit 4.8.36 for easy to migrate to latest stable PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "twig/twig": "^1.12|^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8",
+    "phpunit/phpunit": "^4.8.36",
     "scrutinizer/ocular": "~1.3",
     "satooshi/php-coveralls": "^1.0",
     "friendsofphp/php-cs-fixer": "~2.2",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,12 +10,15 @@
 
 namespace GpsLab\Bundle\PaginationBundle\Tests;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
 {
     /**
      * @param string $class_name
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit_Framework_MockObject_MockObject|MockObject
      */
     protected function getMockNoConstructor($class_name)
     {
@@ -28,9 +31,8 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * @param string $class_name
-     * @param array  $methods
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit_Framework_MockObject_MockObject|MockObject
      */
     protected function getMockAbstract($class_name, array $methods)
     {


### PR DESCRIPTION
Using the final PHPUnit [4.8.36](https://github.com/sebastianbergmann/phpunit/releases/tag/4.8.36) version and it can be easy to migrate to latest stable PHPUnit version in the future.