### PR TITLE
Disable no_superfluous_phpdoc_tags rule of php-cs-fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,6 +15,7 @@ return PhpCsFixer\Config::create()
             'header' => $header,
         ],
         'array_syntax' => ['syntax' => 'short'],
+        'no_superfluous_phpdoc_tags' => false,
         'yoda_style' => false,
         'ordered_imports' => [
             'sort_algorithm' => 'alpha',


### PR DESCRIPTION
Disable `no_superfluous_phpdoc_tags` rule of [PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).