### PR TITLE
Allow change max_navigate param in templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Display pagination in template:
  * [From QueryBuilder](docs/from_qb.md)
  * [From HTTP request](docs/from_request.md)
  * [From HTTP request and QueryBuilder](docs/from_request_and_qb.md)
+ * [Page range](docs/page_range.md)
  * [Custom view](docs/custom_view.md)
 
 ## License

--- a/docs/page_range.md
+++ b/docs/page_range.md
@@ -1,0 +1,25 @@
+Page range
+==========
+
+You can customize maximum pages in navigation menu.
+
+## Configuration
+
+```yaml
+gpslab_pagination:
+    max_navigate: 10
+```
+
+## Controller
+
+```php
+$pagination->setMaxNavigate(10);
+```
+
+## Templates
+
+```twig
+<nav class="pagination">
+    {{- pagination_render(pagination, null, [], 10) -}}
+</nav>
+```

--- a/src/Twig/Extension/PaginationExtension.php
+++ b/src/Twig/Extension/PaginationExtension.php
@@ -49,6 +49,7 @@ class PaginationExtension extends AbstractExtension
      * @param Configuration     $pagination
      * @param string            $template
      * @param array             $view_params
+     * @param int               $max_navigate
      *
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\RuntimeError
@@ -60,11 +61,22 @@ class PaginationExtension extends AbstractExtension
         Environment $env,
         Configuration $pagination,
         $template = null,
-        array $view_params = []
+        array $view_params = [],
+        $max_navigate = 0
     ) {
+        if ($max_navigate > 0) {
+            // not change original object
+            $new_pagination = clone $pagination;
+            $new_pagination->setMaxNavigate($max_navigate);
+
+            $pagination_view = $new_pagination->getView();
+        } else {
+            $pagination_view = $pagination->getView();
+        }
+
         return $env->render(
             $template ?: $this->template,
-            array_merge($view_params, ['pagination' => $pagination->getView()])
+            array_merge($view_params, ['pagination' => $pagination_view])
         );
     }
 


### PR DESCRIPTION
Allow change `max_navigate` parameter in templating like this:

```twig
<nav class="pagination">
    {{- pagination_render(pagination, null, [], 10) -}}
</nav>
```