### PR TITLE
Not require-dev "roave/security-advisories"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "phpunit/phpunit": "^4.8.36",
     "scrutinizer/ocular": "~1.3",
     "php-coveralls/php-coveralls": "^1.0",
-    "friendsofphp/php-cs-fixer": "~2.2",
-    "roave/security-advisories": "dev-master"
+    "friendsofphp/php-cs-fixer": "~2.2"
   }
 }


### PR DESCRIPTION
[Roave Security Advisories](https://github.com/Roave/SecurityAdvisories) should not be used in libraries.