### PR TITLE
Install Scrutinizer ocular and php-coveralls as phar (not by composer)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,5 +80,7 @@ script:
     - vendor/bin/phpunit --coverage-clover build/coverage-clover.xml
 
 after_script:
-    - vendor/bin/ocular code-coverage:upload --format=php-clover build/coverage-clover.xml
-    - vendor/bin/coveralls -v -c .coveralls.yml
+    - wget https://scrutinizer-ci.com/ocular.phar
+    - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.2.0/php-coveralls.phar
+    - php ocular.phar code-coverage:upload --format=php-clover build/coverage-clover.xml
+    - php php-coveralls.phar -v -c .coveralls.yml

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
     "twig/twig": "^1.34|^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36",
-    "scrutinizer/ocular": "~1.3",
-    "php-coveralls/php-coveralls": "^1.0",
-    "friendsofphp/php-cs-fixer": "~2.2"
+    "phpunit/phpunit": "^4.8.36"
   }
 }


### PR DESCRIPTION
Unnecessary dependencies lead to [conflict](https://travis-ci.org/gpslab/pagination-bundle/builds/657185451).