### PR TITLE
Add docs about configuration request parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Display pagination in template:
  * [From QueryBuilder](docs/from_qb.md)
  * [From HTTP request](docs/from_request.md)
  * [From HTTP request and QueryBuilder](docs/from_request_and_qb.md)
- * [Page range](docs/page_range.md)
+ * [Request parameter name](docs/parameter_name.md)
+ * [Navigation pages range](docs/page_range.md)
  * [Custom view](docs/custom_view.md)
 
 ## License

--- a/docs/page_range.md
+++ b/docs/page_range.md
@@ -1,16 +1,18 @@
-Page range
-==========
+Navigation pages range
+======================
 
 You can customize maximum pages in navigation menu.
 
-## Configuration
+Configuration
+-------------
 
 ```yaml
 gpslab_pagination:
     max_navigate: 10
 ```
 
-## Templates
+Templates
+---------
 
 ```twig
 <nav class="pagination">
@@ -18,13 +20,15 @@ gpslab_pagination:
 </nav>
 ```
 
-## Controller
+Controller
+----------
 
 ```php
 $pagination->setMaxNavigate(10);
 ```
 
-## Annotations
+Annotations
+-----------
 
 ```php
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;

--- a/docs/parameter_name.md
+++ b/docs/parameter_name.md
@@ -1,0 +1,41 @@
+Request parameter name
+======================
+
+As default used `page` as request parameter name. So for first page will be generated `/` link, for second `/?page=2`,
+for third `/?page=3` and etc. You can change this parameter name.
+
+Configuration
+-------------
+
+```yaml
+gpslab_pagination:
+    parameter_name: 'p'
+```
+
+Controller
+----------
+
+```php
+$pagination = new Configuration();
+$pagination->setFirstPageLink('/');
+$pagination->setPageLink('/?p=%d');
+// or you can use callback function
+//$pagination->setPageLink(static function (int $number): string {
+//    return sprintf('/?p=%d', $number);
+//});
+```
+
+Annotations
+-----------
+
+```php
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+/**
+ * @ParamConverter("pagination", options={"parameter_name": "p"})
+ */
+public function index(Configuration $pagination): Response
+{
+    // ...
+}
+```


### PR DESCRIPTION
Request parameter name
======================

As default used `page` as request parameter name. So for first page will be generated `/` link, for second `/?page=2`, for third `/?page=3` and etc. You can change this parameter name.

Configuration
-------------

```yaml
gpslab_pagination:
    parameter_name: 'p'
```

Controller
----------

```php
$pagination = new Configuration();
$pagination->setFirstPageLink('/');
$pagination->setPageLink('/?p=%d');
// or you can use callback function
//$pagination->setPageLink(static function (int $number): string {
//    return sprintf('/?p=%d', $number);
//});
```

Annotations
-----------

```php
use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;

/**
 * @ParamConverter("pagination", options={"parameter_name": "p"})
 */
public function index(Configuration $pagination): Response
{
    // ...
}
```